### PR TITLE
refactor: install published bins on macOS

### DIFF
--- a/usage.rb
+++ b/usage.rb
@@ -1,20 +1,37 @@
 class Usage < Formula
   desc "Tool for CLIs"
   homepage "https://github.com/jdx/usage"
-  url "https://github.com/jdx/usage/archive/refs/tags/v0.1.17.tar.gz"
-  sha256 "735d08fbe78e2c0390afa8ee23dfbc7cd54f4ae9355359875d7e23a01084dba6"
   license "MIT"
-  head "https://github.com/jdx/usage.git", branch: "main"
 
   livecheck do
     url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on "rust" => :build
+  head do
+    url "https://github.com/jdx/usage.git", branch: "main"
+
+    depends_on "rust" => :build
+  end
+
+  on_macos do
+    url "https://github.com/jdx/usage/releases/download/v0.1.17/usage-universal-apple-darwin.tar.gz"
+    sha256 "2f051644e60b8bc9ac28a847da82bc2320edb593c41fdb0dad0e565f8ebd2c2e"
+  end
+
+  on_linux do
+    url "https://github.com/jdx/usage/archive/refs/tags/v0.1.17.tar.gz"
+    sha256 "735d08fbe78e2c0390afa8ee23dfbc7cd54f4ae9355359875d7e23a01084dba6"
+
+    depends_on "rust" => :build
+  end
 
   def install
-    system "cargo", "install", *std_cargo_args(path: "cli")
+    if OS.mac? && !build.head?
+      bin.install "usage"
+    else
+      system "cargo", "install", *std_cargo_args(path: "cli")
+    end
   end
 
   test do


### PR DESCRIPTION
Now that https://github.com/jdx/usage is publishing prebuilt binaries as part of the releases, this updates the Homebrew formula to install that prebuilt binary on macOS.

Installing the prebuilt binary saves having to install `rust` (which, as of writing, in turn depends on `z3`, `llvm`, and `pkg-config`) through Homebrew.

I wasn't entirely sure how much a priority Linux support is for this formula, especially since there are GNU and musl Linux binaries published for `usage`. Right now this change retains installing via `cargo` for non-macOS and `HEAD`-based installs, but this could be easily changed to install the Linux binary for the installing architecture (though it would have to use the `musl` binary as I don't think Homebrew gives a way to detect GNU).